### PR TITLE
Alter library to support streaming from a ringbuffer

### DIFF
--- a/include/rnnoise.h
+++ b/include/rnnoise.h
@@ -49,4 +49,8 @@ RNNOISE_EXPORT DenoiseState *rnnoise_create();
 
 RNNOISE_EXPORT void rnnoise_destroy(DenoiseState *st);
 
-RNNOISE_EXPORT float rnnoise_process_frame(DenoiseState *st, float *out, const float *in);
+RNNOISE_EXPORT size_t rnnoise_need_samples(DenoiseState *st);
+
+RNNOISE_EXPORT size_t rnnoise_add_samples(DenoiseState *st, const float *in, size_t samples);
+
+RNNOISE_EXPORT float rnnoise_process_frame(DenoiseState *st, float *out);

--- a/src/denoise.c
+++ b/src/denoise.c
@@ -84,6 +84,9 @@ typedef struct {
 } CommonState;
 
 struct DenoiseState {
+  float input[FRAME_SIZE];
+  size_t input_pos;
+
   float analysis_mem[FRAME_SIZE];
   float cepstral_mem[CEPS_MEM][NB_BANDS];
   int memid;
@@ -468,11 +471,30 @@ void pitch_filter(kiss_fft_cpx *X, const kiss_fft_cpx *P, const float *Ex, const
   }
 }
 
-float rnnoise_process_frame(DenoiseState *st, float *out, const float *in) {
+size_t rnnoise_need_samples(DenoiseState *st) {
+  return FRAME_SIZE - st->input_pos;
+}
+
+size_t rnnoise_add_samples(DenoiseState *st, const float *in, size_t samples) {
+  static const float a_hp[2] = {-1.99599, 0.99600};
+  static const float b_hp[2] = {-2, 1};
+
+  if (FRAME_SIZE - st->input_pos < samples)
+    samples = FRAME_SIZE - st->input_pos;
+
+  if (!samples)
+    return 0;
+
+  biquad(st->input + st->input_pos, st->mem_hp_x, in, b_hp, a_hp, samples);
+  st->input_pos += samples;
+
+  return samples;
+}
+
+float rnnoise_process_frame(DenoiseState *st, float *out) {
   int i;
   kiss_fft_cpx X[FREQ_SIZE];
   kiss_fft_cpx P[WINDOW_SIZE];
-  float x[FRAME_SIZE];
   float Ex[NB_BANDS], Ep[NB_BANDS];
   float Exp[NB_BANDS];
   float features[NB_FEATURES];
@@ -480,10 +502,10 @@ float rnnoise_process_frame(DenoiseState *st, float *out, const float *in) {
   float gf[FREQ_SIZE]={1};
   float vad_prob = 0;
   int silence;
-  static const float a_hp[2] = {-1.99599, 0.99600};
-  static const float b_hp[2] = {-2, 1};
-  biquad(x, st->mem_hp_x, in, b_hp, a_hp, FRAME_SIZE);
-  silence = compute_frame_features(st, X, P, Ex, Ep, Exp, features, x);
+
+  celt_assert(st->input_pos == FRAME_SIZE);
+  silence = compute_frame_features(st, X, P, Ex, Ep, Exp, features, st->input);
+  st->input_pos = 0;
 
   if (!silence) {
     compute_rnn(&st->rnn, g, &vad_prob, features);


### PR DESCRIPTION
This change allows an application to stream from non contiguous memory avoiding the need for an intermediate buffer. For example:

    size_t need;

    while((need = rnnoise_need_samples(state) && buffer_available() >= need) {
      float * samples;
      size_t available = buffer_get_contiguous(need, &samples);
      rnnoise_add_samples(state, samples, available);
    }

    if (need == 0)  {
      rnnopise_process_frame(state, output);      
      // process the output
    }
    