### PR TITLE
Windows, CMake, C++ support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.1)
+project(rnnoise)
+
+# Get source files
+file(GLOB SOURCES "src/*.c" "src/*.h" "include/*.h")
+
+# Compile the library
+add_library(rnnoise STATIC ${SOURCES})
+
+# Include dirs
+target_include_directories(rnnoise PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:include>
+        PRIVATE src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,36 @@
 cmake_minimum_required(VERSION 3.1)
 project(rnnoise)
 
+option(RNNOISE_COMPILE_OPUS ON)
+
+if(RNNOISE_COMPILE_OPUS)
+	add_definitions(-DCOMPILE_OPUS)
+endif()
+
+# Ignore CRT warnings
+add_definitions(-D_CRT_SECURE_NO_WARNINGS)
+
 # Get source files
 file(GLOB SOURCES "src/*.c" "src/*.h" "include/*.h")
 
+# Build rnnoise
+add_definitions(-DRNNOISE_BUILD)
+
 # Compile the library
-add_library(rnnoise STATIC ${SOURCES})
+add_library(rnnoise ${SOURCES})
+
+# Build DLL if needed
+if(BUILD_SHARED_LIBS)
+  if(WIN32)
+    target_compile_definitions(rnnoise PRIVATE DLL_EXPORT)
+  else()
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag(-fvisibility=hidden COMPILER_HAS_HIDDEN_VISIBILITY)
+    if(COMPILER_HAS_HIDDEN_VISIBILITY)
+      set_target_properties(rnnoise PROPERTIES C_VISIBILITY_PRESET hidden)
+    endif()
+  endif()
+endif()
 
 # Include dirs
 target_include_directories(rnnoise PUBLIC

--- a/include/rnnoise.h
+++ b/include/rnnoise.h
@@ -30,7 +30,6 @@
 
 #include <stdio.h>
 
-
 #ifndef RNNOISE_EXPORT
 # if defined(WIN32)
 #  if defined(RNNOISE_BUILD) && defined(DLL_EXPORT)
@@ -43,6 +42,10 @@
 # else
 #  define RNNOISE_EXPORT
 # endif
+#endif
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
 typedef struct DenoiseState DenoiseState;
@@ -62,4 +65,7 @@ RNNOISE_EXPORT RNNModel *rnnoise_model_from_file(FILE *f);
 
 RNNOISE_EXPORT void rnnoise_model_free(RNNModel *model);
 
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src/celt_lpc.c
+++ b/src/celt_lpc.c
@@ -96,7 +96,7 @@ void celt_fir(
          int ord)
 {
    int i,j;
-   opus_val16 rnum[ord];
+   opus_val16 *rnum = malloc(sizeof(opus_val16) * ord);
    for(i=0;i<ord;i++)
       rnum[i] = num[ord-i-1];
    for (i=0;i<N-3;i+=4)
@@ -119,6 +119,7 @@ void celt_fir(
          sum = MAC16_16(sum,rnum[j],x[i+j-ord]);
       y[i] = ROUND16(sum, SIG_SHIFT);
    }
+   free(rnum);
 }
 
 void celt_iir(const opus_val32 *_x,
@@ -147,8 +148,8 @@ void celt_iir(const opus_val32 *_x,
 #else
    int i,j;
    celt_assert((ord&3)==0);
-   opus_val16 rden[ord];
-   opus_val16 y[N+ord];
+   opus_val16 *rden = malloc(sizeof(opus_val16) * ord);
+   opus_val16 *y = malloc(sizeof(opus_val16) * (N + ord));
    for(i=0;i<ord;i++)
       rden[i] = den[ord-i-1];
    for(i=0;i<ord;i++)
@@ -192,6 +193,8 @@ void celt_iir(const opus_val32 *_x,
    }
    for(i=0;i<ord;i++)
       mem[i] = _y[N-i-1];
+   free(rden);
+   free(y);
 #endif
 }
 
@@ -208,7 +211,7 @@ int _celt_autocorr(
    int fastN=n-lag;
    int shift;
    const opus_val16 *xptr;
-   opus_val16 xx[n];
+   opus_val16 *xx = malloc(sizeof(opus_val16) * n);
    celt_assert(n>0);
    celt_assert(overlap>=0);
    if (overlap == 0)
@@ -274,6 +277,6 @@ int _celt_autocorr(
       shift += shift2;
    }
 #endif
-
+   free(xx);
    return shift;
 }

--- a/src/denoise.c
+++ b/src/denoise.c
@@ -29,6 +29,8 @@
 #include "config.h"
 #endif
 
+#define _USE_MATH_DEFINES
+
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/kiss_fft.c
+++ b/src/kiss_fft.c
@@ -515,6 +515,7 @@ void opus_fft_free(const kiss_fft_state *cfg, int arch)
 
 #endif /* CUSTOM_MODES */
 
+#ifdef COMPILE_OPUS
 void opus_fft_impl(const kiss_fft_state *st,kiss_fft_cpx *fout)
 {
     int m2, m;
@@ -599,3 +600,4 @@ void opus_ifft_c(const kiss_fft_state *st,const kiss_fft_cpx *fin,kiss_fft_cpx *
    for (i=0;i<st->nfft;i++)
       fout[i].i = -fout[i].i;
 }
+#endif

--- a/src/pitch.c
+++ b/src/pitch.c
@@ -297,9 +297,9 @@ void pitch_search(const opus_val16 *x_lp, opus_val16 *y,
    celt_assert(max_pitch>0);
    lag = len+max_pitch;
 
-   opus_val16 x_lp4[len>>2];
-   opus_val16 y_lp4[lag>>2];
-   opus_val32 xcorr[max_pitch>>1];
+   opus_val16 *x_lp4 = malloc(sizeof(opus_val16) * (len >> 2));
+   opus_val16 *y_lp4 = malloc(sizeof(opus_val16) * (lag >> 2));
+   opus_val32 *xcorr = malloc(sizeof(opus_val32) * (max_pitch >> 1));
 
    /* Downsample by 2 again */
    for (j=0;j<len>>2;j++)
@@ -382,6 +382,10 @@ void pitch_search(const opus_val16 *x_lp, opus_val16 *y,
       offset = 0;
    }
    *pitch = 2*best_pitch[0]-offset;
+
+   free(x_lp4);
+   free(y_lp4);
+   free(xcorr);
 }
 
 #ifdef FIXED_POINT
@@ -443,7 +447,7 @@ opus_val16 remove_doubling(opus_val16 *x, int maxperiod, int minperiod,
       *T0_=maxperiod-1;
 
    T = T0 = *T0_;
-   opus_val32 yy_lookup[maxperiod+1];
+   opus_val32 *yy_lookup = malloc(sizeof(opus_val32) * (maxperiod + 1));
    dual_inner_prod(x, x, x-T0, N, &xx, &xy);
    yy_lookup[0] = xx;
    yy=xx;
@@ -522,5 +526,7 @@ opus_val16 remove_doubling(opus_val16 *x, int maxperiod, int minperiod,
 
    if (*T0_<minperiod0)
       *T0_=minperiod0;
+
+   free(yy_lookup);
    return pg;
 }

--- a/src/rnn.c
+++ b/src/rnn.c
@@ -76,6 +76,7 @@ static OPUS_INLINE float relu(float x)
    return x < 0 ? 0 : x;
 }
 
+#ifdef COMPILE_OPUS
 void compute_dense(const DenseLayer *layer, float *output, const float *input)
 {
    int i, j;
@@ -154,6 +155,7 @@ void compute_gru(const GRULayer *gru, float *state, const float *input)
    for (i=0;i<N;i++)
       state[i] = h[i];
 }
+#endif
 
 #define INPUT_SIZE 42
 

--- a/src/rnn.c
+++ b/src/rnn.c
@@ -76,8 +76,7 @@ static OPUS_INLINE float relu(float x)
    return x < 0 ? 0 : x;
 }
 
-#ifdef COMPILE_OPUS
-void compute_dense(const DenseLayer *layer, float *output, const float *input)
+static void compute_dense(const DenseLayer *layer, float *output, const float *input)
 {
    int i, j;
    int N, M;
@@ -107,7 +106,7 @@ void compute_dense(const DenseLayer *layer, float *output, const float *input)
    }
 }
 
-void compute_gru(const GRULayer *gru, float *state, const float *input)
+static void compute_gru(const GRULayer *gru, float *state, const float *input)
 {
    int i, j;
    int N, M;
@@ -155,7 +154,6 @@ void compute_gru(const GRULayer *gru, float *state, const float *input)
    for (i=0;i<N;i++)
       state[i] = h[i];
 }
-#endif
 
 #define INPUT_SIZE 42
 

--- a/src/rnn.h
+++ b/src/rnn.h
@@ -60,10 +60,6 @@ typedef struct {
 
 typedef struct RNNState RNNState;
 
-void compute_dense(const DenseLayer *layer, float *output, const float *input);
-
-void compute_gru(const GRULayer *gru, float *state, const float *input);
-
 void compute_rnn(RNNState *rnn, float *gains, float *vad, const float *input);
 
 #endif /* _MLP_H_ */


### PR DESCRIPTION
This PR includes the following changes:

* Removed the use of VLA in order to support MSVC that doesn't have implementation for VLA and fixed more issues that occurred during the compile on Windows.
* Add CMakeLists.txt to support compile using CMake.
* Allowed the library to be linked against C++ code (missing extern "C").