### PR TITLE
Drop unused arguments from README

### DIFF
--- a/README
+++ b/README
@@ -12,6 +12,6 @@ While it is meant to be used as a library, a simple command-line tool is
 provided as an example. It operates on RAW 16-bit (machine endian) mono
 PCM files sampled at 48 kHz. It can be used as:
 
-./examples/rnnoise_demo <number of channels> <maximum attenuation> < input.raw > output.raw
+./examples/rnnoise_demo <input.raw> output.raw
 
 The output is also a 16-bit raw PCM file.

--- a/README
+++ b/README
@@ -12,6 +12,6 @@ While it is meant to be used as a library, a simple command-line tool is
 provided as an example. It operates on RAW 16-bit (machine endian) mono
 PCM files sampled at 48 kHz. It can be used as:
 
-./examples/rnnoise_demo <input.raw> output.raw
+./examples/rnnoise_demo <noisy speech> <output denoised>
 
 The output is also a 16-bit raw PCM file.


### PR DESCRIPTION
When trying to run the example, the script spits out 
`usage: rnnoise_demo <noisy speech> <output denoised>`

I think this should be in the readme as the `rnnoise_demo` does not seem to accept neither `number of channels` nor `maximum attenuation` arguments. 