### PR TITLE
Basic cmake support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(rnnoise)
+
+set(CMAKE_CXX_STANDARD 11)
+
+add_subdirectory( src )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,0 +1,17 @@
+set (library_sources 
+	denoise.c
+	rnn.c
+	rnn_data.c
+	rnn_reader.c
+	pitch.c
+	kiss_fft.c
+	celt_lpc.c
+)
+
+add_library(rnnoise SHARED ${library_sources})
+include_directories(rnnoise ../include)
+add_library(rnnoise_static ${library_sources})
+include_directories(rnnoise_static ../include)
+set_target_properties(rnnoise_static PROPERTIES OUTPUT_NAME rnnoise)
+
+


### PR DESCRIPTION
When building for Apple silicon I found it really annoying to make autotool to create a universal binary. So I had to implement a basic cmake. Then I had to set CMAKE_OSX_ARCHITECTURES=arm64;x86_64 and that gives me what I want. If you need any help improving Cmake support, please let me know - I have enough XP here