### PR TITLE
Fix Wstrict-prototypes warnings

### DIFF
--- a/include/rnnoise.h
+++ b/include/rnnoise.h
@@ -54,12 +54,12 @@ typedef struct RNNModel RNNModel;
 /**
  * Return the size of DenoiseState
  */
-RNNOISE_EXPORT int rnnoise_get_size();
+RNNOISE_EXPORT int rnnoise_get_size(void);
 
 /**
  * Return the number of samples processed by rnnoise_process_frame at a time
  */
-RNNOISE_EXPORT int rnnoise_get_frame_size();
+RNNOISE_EXPORT int rnnoise_get_frame_size(void);
 
 /**
  * Initializes a pre-allocated DenoiseState

--- a/src/denoise.c
+++ b/src/denoise.c
@@ -165,7 +165,7 @@ void interp_band_gain(float *g, const float *bandE) {
 
 CommonState common;
 
-static void check_init() {
+static void check_init(void) {
   int i;
   if (common.init) return;
   common.kfft = opus_fft_alloc_twiddles(2*FRAME_SIZE, NULL, NULL, NULL, 0);
@@ -253,11 +253,11 @@ static void apply_window(float *x) {
   }
 }
 
-int rnnoise_get_size() {
+int rnnoise_get_size(void) {
   return sizeof(DenoiseState);
 }
 
-int rnnoise_get_frame_size() {
+int rnnoise_get_frame_size(void) {
   return FRAME_SIZE;
 }
 


### PR DESCRIPTION
e.g.:
```
./include/rnnoise.h:51:36: warning: a function declaration without a prototype is deprecated in all versions of C [-Wstrict-prototypes]
RNNOISE_EXPORT int rnnoise_get_size();
                                   ^
                                    void
```