### PR TITLE
handle non-vla compilers

### DIFF
--- a/src/arch.h
+++ b/src/arch.h
@@ -258,4 +258,15 @@ static OPUS_INLINE int celt_isnan(float x)
 #endif
 #endif
 
+#if __STDC_VERSION__ < 199901L || (__STDC_VERSION__ > 201000L && __STDC_NO_VLA__ == 1)
+   #define NO_VLA
+#endif
+
+#ifdef NO_VLA
+    #include <malloc.h>
+    #define stackalloc(type, id, len) type *id = alloca(len)
+#else
+    #define stackalloc(type, id, len) type id[len]
+#endif
+
 #endif /* ARCH_H */

--- a/src/celt_lpc.c
+++ b/src/celt_lpc.c
@@ -96,7 +96,7 @@ void celt_fir(
          int ord)
 {
    int i,j;
-   opus_val16 rnum[ord];
+   stackalloc(opus_val16, rnum, ord);
    for(i=0;i<ord;i++)
       rnum[i] = num[ord-i-1];
    for (i=0;i<N-3;i+=4)
@@ -147,8 +147,8 @@ void celt_iir(const opus_val32 *_x,
 #else
    int i,j;
    celt_assert((ord&3)==0);
-   opus_val16 rden[ord];
-   opus_val16 y[N+ord];
+   stackalloc(opus_val16, rden, ord);
+   stackalloc(opus_val16, y, N+ord);
    for(i=0;i<ord;i++)
       rden[i] = den[ord-i-1];
    for(i=0;i<ord;i++)
@@ -208,7 +208,7 @@ int _celt_autocorr(
    int fastN=n-lag;
    int shift;
    const opus_val16 *xptr;
-   opus_val16 xx[n];
+   stackalloc(opus_val16, xx, n);
    celt_assert(n>0);
    celt_assert(overlap>=0);
    if (overlap == 0)

--- a/src/pitch.c
+++ b/src/pitch.c
@@ -297,9 +297,9 @@ void pitch_search(const opus_val16 *x_lp, opus_val16 *y,
    celt_assert(max_pitch>0);
    lag = len+max_pitch;
 
-   opus_val16 x_lp4[len>>2];
-   opus_val16 y_lp4[lag>>2];
-   opus_val32 xcorr[max_pitch>>1];
+   stackalloc(opus_val16, x_lp4, len>>2);
+   stackalloc(opus_val16, y_lp4, lag>>2);
+   stackalloc(opus_val32, xcorr, max_pitch>>1);
 
    /* Downsample by 2 again */
    for (j=0;j<len>>2;j++)
@@ -443,7 +443,7 @@ opus_val16 remove_doubling(opus_val16 *x, int maxperiod, int minperiod,
       *T0_=maxperiod-1;
 
    T = T0 = *T0_;
-   opus_val32 yy_lookup[maxperiod+1];
+   stackalloc(opus_val32, yy_lookup, maxperiod+1);
    dual_inner_prod(x, x, x-T0, N, &xx, &xy);
    yy_lookup[0] = xx;
    yy=xx;


### PR DESCRIPTION
Leverages the C std version and the standard `__STDC_NO_VLA__` macro to detect whether VLA is supported, and if not falls back to using alloca.

This is needed to support the MSVC compiler.  With this (and defining `M_PI`) I was able to compile rnnoise with MSVC.