### PR TITLE
Fix SIMD fallback code when AVX2 is not available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/models
+/src/rnnoise_data.c
+/src/rnnoise_data.h
+/src/rnnoise_data_little.c
+/src/rnnoise_data_little.h

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -168,8 +168,8 @@ typedef struct {
   __m128i lo;
   __m128i hi;
 } mm256i_emu;
-typedef __m256i real_m256i;
 #define __m256i mm256i_emu
+typedef __m256i real_m256i;
 
 static inline mm256i_emu mm256_setzero_si256(void) {
   mm256i_emu ret;


### PR DESCRIPTION
Currently the code first `typedef`s a fallback type based on `__m256i` and only on the following line it actually defines `__m256i` as the emulated type. This needs to be the other way around!

This PR also adds a basic .gitignore for the recently-added downloaded model files.