### PR TITLE
Pass "z" flag to tar when unpacking gzipped model

### DIFF
--- a/download_model.sh
+++ b/download_model.sh
@@ -27,5 +27,5 @@ else
 fi
 
 
-tar xvomf $model
+tar xzvomf $model
 


### PR DESCRIPTION
`download_model.sh` didn't work for me on OpenBSD, because the tar call didn't include the "z" flag, although the downloaded model was compressed with gzip.