### PR TITLE
Fixed Issue when `USE_WEIGHTS_FILE` Flag Enabled

### DIFF
--- a/compile_demo_project_with_blob.sh
+++ b/compile_demo_project_with_blob.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+echo ##########
+echo "Compiling Demo..."
+echo ##########
+
+gcc -o rnnoise_demo \
+	examples/rnnoise_demo.c \
+	src/celt_lpc.c src/denoise.c src/kiss_fft.c \
+	src/nnet.c src/nnet_default.c src/parse_lpcnet_weights.c \
+	src/pitch.c src/rnn.c src/rnnoise_tables.c \
+	-I./include -I./src \
+	-lm \
+	-DUSE_WEIGHTS_FILE
+
+echo ##########
+echo "Compiled rnnoise_demo !!"
+ls -alh | grep rnnoise_demo
+echo ##########

--- a/compile_demo_project_without_blob.sh
+++ b/compile_demo_project_without_blob.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+echo ##########
+echo "Compiling Demo..."
+echo ##########
+
+gcc -o rnnoise_demo \
+	examples/rnnoise_demo.c \
+	src/celt_lpc.c src/denoise.c src/kiss_fft.c \
+	src/nnet.c src/nnet_default.c src/parse_lpcnet_weights.c \
+	src/pitch.c src/rnn.c src/rnnoise_data.c src/rnnoise_tables.c \
+	-I./include -I./src \
+	-lm
+
+echo ##########
+echo "Compiled rnnoise_demo !!"
+ls -alh | grep rnnoise_demo
+echo ##########

--- a/generate_weights_blob.sh
+++ b/generate_weights_blob.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+echo ##########
+echo "Compiling Generator..."
+echo ##########
+
+gcc -o generate_weights_blob \
+	src/write_weights.c src/parse_lpcnet_weights.c
+
+echo ##########
+echo "Generating weights_blob.bin..."
+echo ##########
+
+./generate_weights_blob
+
+echo ##########
+echo "Generated weights_blob.bin !!"
+ls -alh | grep weights_blob.bin
+echo ##########

--- a/src/denoise.c
+++ b/src/denoise.c
@@ -282,6 +282,23 @@ int rnnoise_get_frame_size(void) {
   return FRAME_SIZE;
 }
 
+#ifndef DUMP_BINARY_WEIGHTS
+int init_rnnoise(RNNoise *model, const WeightArray *arrays) {
+    if (linear_init(&model->conv1, arrays, "conv1_bias", NULL, NULL,"conv1_weights_float", NULL, NULL, NULL, 195, 128)) return 1;
+    if (linear_init(&model->conv2, arrays, "conv2_bias", "conv2_subias", "conv2_weights_int8","conv2_weights_float", NULL, NULL, "conv2_scale", 384, 384)) return 1;
+    if (linear_init(&model->gru1_input, arrays, "gru1_input_bias", "gru1_input_subias", "gru1_input_weights_int8","gru1_input_weights_float", "gru1_input_weights_idx", NULL, "gru1_input_scale", 384, 1152)) return 1;
+    if (linear_init(&model->gru1_recurrent, arrays, "gru1_recurrent_bias", "gru1_recurrent_subias", "gru1_recurrent_weights_int8","gru1_recurrent_weights_float", "gru1_recurrent_weights_idx", "gru1_recurrent_weights_diag", "gru1_recurrent_scale", 384, 1152)) return 1;
+    if (linear_init(&model->gru2_input, arrays, "gru2_input_bias", "gru2_input_subias", "gru2_input_weights_int8","gru2_input_weights_float", "gru2_input_weights_idx", NULL, "gru2_input_scale", 384, 1152)) return 1;
+    if (linear_init(&model->gru2_recurrent, arrays, "gru2_recurrent_bias", "gru2_recurrent_subias", "gru2_recurrent_weights_int8","gru2_recurrent_weights_float", "gru2_recurrent_weights_idx", "gru2_recurrent_weights_diag", "gru2_recurrent_scale", 384, 1152)) return 1;
+    if (linear_init(&model->gru3_input, arrays, "gru3_input_bias", "gru3_input_subias", "gru3_input_weights_int8","gru3_input_weights_float", "gru3_input_weights_idx", NULL, "gru3_input_scale", 384, 1152)) return 1;
+    if (linear_init(&model->gru3_recurrent, arrays, "gru3_recurrent_bias", "gru3_recurrent_subias", "gru3_recurrent_weights_int8","gru3_recurrent_weights_float", "gru3_recurrent_weights_idx", "gru3_recurrent_weights_diag", "gru3_recurrent_scale", 384, 1152)) return 1;
+    if (linear_init(&model->dense_out, arrays, "dense_out_bias", NULL, NULL,"dense_out_weights_float", NULL, NULL, NULL, 1536, 32)) return 1;
+    if (linear_init(&model->vad_dense, arrays, "vad_dense_bias", NULL, NULL,"vad_dense_weights_float", NULL, NULL, NULL, 1536, 1)) return 1;
+
+    return 0;
+}
+#endif
+
 int rnnoise_init(DenoiseState *st, RNNModel *model) {
   memset(st, 0, sizeof(*st));
 #if !TRAINING


### PR DESCRIPTION
## Summary
Fixed some issues when `USE_WEIGHTS_FILE` Flag is enabled.

## Description
- When `USE_WEIGHTS_FILE` Flag is enabled, `rnnoise_data.c` which has huge huge lines is not used for compile program. But `init_rnnoise` Function is included in `rnnoise_data.c` so compile must be needed.
- So moved `init_rnnoise` Function into `denoise.c`.
- And also, when generate `weight_blob.bin` with `write_weights.c`, it generated `.bin` file with `w` mode, but we are generating just `b` file so I edited `w` as `wb` of file function parameter.
- `write_weights.c` has same work as old one, but I improved code readability and debugability.
- `.sh` scripts are compile helper for debuggers.
- I think almost guys contributing this project are related to AI, ML, or Audio Training, but I am just Android developer so I got too hard to use this project. I think this PR fixed some many of just developmenting issue using this project. Please merge this PR so that many client developers can use this project for their projects.