### PR TITLE
Add CMake support, fix building under MSVC, fix RTCD detection, add AVX512 variant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,508 @@
+cmake_minimum_required(VERSION 3.23)
+
+project(rnnoise
+    VERSION 0.2.0
+    DESCRIPTION "RNN-based noise suppression"
+    LANGUAGES C
+)
+
+include(CheckCCompilerFlag)
+include(CheckLibraryExists)
+include(CMakePackageConfigHelpers)
+include(GNUInstallDirs)
+
+# ------------------------------------------------------------------------------
+# Options
+# ------------------------------------------------------------------------------
+
+option(RNNOISE_BUILD_EXAMPLES
+    "Build example applications"
+    ON
+)
+
+option(RNNOISE_BUILD_DOCS
+    "Build API documentation when Doxygen is available"
+    ON
+)
+
+option(RNNOISE_ENABLE_DNN_DEBUG_FLOAT
+    "Use floating-point DNN computation everywhere"
+    OFF
+)
+
+option(RNNOISE_DOWNLOAD_MODEL
+    "Download the default RNNoise model"
+    OFF
+)
+
+if(WIN32)
+    add_compile_definitions(
+        _WIN32_WINNT=0x0601
+        WIN32_LEAN_AND_MEAN
+        UNICODE
+        _UNICODE
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# Model
+#
+# The model is always built from src/rnnoise_data.c. When downloading is
+# enabled, the archive is downloaded and extracted into the source tree.
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_DOWNLOAD_MODEL)
+    file(READ
+        "${CMAKE_CURRENT_SOURCE_DIR}/model_version"
+        RNNOISE_MODEL_HASH
+    )
+
+    string(STRIP
+        "${RNNOISE_MODEL_HASH}"
+        RNNOISE_MODEL_HASH
+    )
+
+    set(RNNOISE_MODEL_NAME
+        "rnnoise_data-${RNNOISE_MODEL_HASH}.tar.gz"
+    )
+
+    set(RNNOISE_MODEL_ARCHIVE
+        "${CMAKE_CURRENT_SOURCE_DIR}/${RNNOISE_MODEL_NAME}"
+    )
+
+    file(DOWNLOAD
+        "https://media.xiph.org/rnnoise/models/${RNNOISE_MODEL_NAME}"
+        "${RNNOISE_MODEL_ARCHIVE}"
+        EXPECTED_HASH "SHA256=${RNNOISE_MODEL_HASH}"
+        SHOW_PROGRESS
+        STATUS RNNOISE_MODEL_DOWNLOAD_STATUS
+    )
+
+    list(GET
+        RNNOISE_MODEL_DOWNLOAD_STATUS
+        0
+        RNNOISE_MODEL_DOWNLOAD_RESULT
+    )
+
+    if(NOT RNNOISE_MODEL_DOWNLOAD_RESULT EQUAL 0)
+        list(GET
+            RNNOISE_MODEL_DOWNLOAD_STATUS
+            1
+            RNNOISE_MODEL_DOWNLOAD_MESSAGE
+        )
+
+        message(FATAL_ERROR
+            "Failed to download RNNoise model: "
+            "${RNNOISE_MODEL_DOWNLOAD_MESSAGE}"
+        )
+    endif()
+
+    file(ARCHIVE_EXTRACT
+        INPUT "${RNNOISE_MODEL_ARCHIVE}"
+        DESTINATION "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# Library
+# ------------------------------------------------------------------------------
+
+set(RNNOISE_SOURCES
+    src/denoise.c
+    src/rnn.c
+    src/pitch.c
+    src/kiss_fft.c
+    src/celt_lpc.c
+    src/nnet.c
+    src/nnet_default.c
+    src/parse_lpcnet_weights.c
+    src/rnnoise_data.c
+    src/rnnoise_tables.c
+)
+
+add_library(rnnoise
+    ${RNNOISE_SOURCES}
+)
+
+add_library(rnnoise::rnnoise ALIAS rnnoise)
+
+target_compile_features(rnnoise
+    PRIVATE
+        c_std_90
+)
+
+target_include_directories(rnnoise
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_compile_definitions(rnnoise
+    PRIVATE
+        RNNOISE_BUILD
+        $<$<CONFIG:Debug>:OP_ENABLE_ASSERTIONS=1>
+)
+
+if(NOT RNNOISE_ENABLE_DNN_DEBUG_FLOAT)
+    target_compile_definitions(rnnoise
+        PRIVATE
+            DISABLE_DEBUG_FLOAT=1
+    )
+endif()
+
+if(NOT BUILD_SHARED_LIBS)
+    target_compile_definitions(rnnoise
+        PUBLIC
+            RNNOISE_STATIC
+    )
+endif()
+
+set_target_properties(rnnoise PROPERTIES
+    VERSION ${PROJECT_VERSION}
+    SOVERSION ${PROJECT_VERSION_MAJOR}
+    C_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN ON
+)
+
+# ------------------------------------------------------------------------------
+# Compiler warnings
+# ------------------------------------------------------------------------------
+
+if(MSVC)
+    target_compile_options(rnnoise
+        PRIVATE
+            /W4
+    )
+else()
+    target_compile_options(rnnoise
+        PRIVATE
+            -Wall
+            -Wextra
+            -Wpedantic
+            -Wno-sign-compare
+            -Wno-parentheses
+            -Wno-long-long
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# x86-64 compiler ISA support
+#
+# v1: baseline x86-64
+# v2: SSE4.2
+# v3: AVX2 + FMA
+# v4: AVX-512
+# ------------------------------------------------------------------------------
+
+if(MSVC)
+    set(RNNOISE_X86_64_V2_FLAG "/arch:SSE4.2")
+    set(RNNOISE_X86_64_V3_FLAG "/arch:AVX2")
+    set(RNNOISE_X86_64_V4_FLAG "/arch:AVX512")
+else()
+    set(RNNOISE_X86_64_V2_FLAG "-march=x86-64-v2")
+    set(RNNOISE_X86_64_V3_FLAG "-march=x86-64-v3")
+    set(RNNOISE_X86_64_V4_FLAG "-march=x86-64-v4")
+endif()
+
+set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
+
+check_c_compiler_flag(
+    "${RNNOISE_X86_64_V2_FLAG}"
+    RNNOISE_HAVE_X86_64_V2
+)
+
+check_c_compiler_flag(
+    "${RNNOISE_X86_64_V3_FLAG}"
+    RNNOISE_HAVE_X86_64_V3
+)
+
+check_c_compiler_flag(
+    "${RNNOISE_X86_64_V4_FLAG}"
+    RNNOISE_HAVE_X86_64_V4
+)
+
+# ------------------------------------------------------------------------------
+# x86-64 RTCD
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_HAVE_X86_64_V2 OR
+   RNNOISE_HAVE_X86_64_V3 OR
+   RNNOISE_HAVE_X86_64_V4)
+
+    target_sources(rnnoise
+        PRIVATE
+            src/x86/x86_dnn_map.c
+            src/x86/x86cpu.c
+    )
+
+    target_compile_definitions(rnnoise
+        PRIVATE
+            RNN_ENABLE_X86_RTCD=1
+            CPU_INFO_BY_ASM=1
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# x86-64 v2
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_HAVE_X86_64_V2)
+    target_sources(rnnoise
+        PRIVATE
+            src/x86/nnet_sse4_2.c
+    )
+
+    set_source_files_properties(
+        src/x86/nnet_sse4_2.c
+        PROPERTIES
+            COMPILE_OPTIONS "${RNNOISE_X86_64_V2_FLAG}"
+    )
+
+    target_compile_definitions(rnnoise
+        PRIVATE
+            RNNOISE_X86_64_V2=1
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# x86-64 v3
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_HAVE_X86_64_V3)
+    target_sources(rnnoise
+        PRIVATE
+            src/x86/nnet_avx2.c
+    )
+
+    set_source_files_properties(
+        src/x86/nnet_avx2.c
+        PROPERTIES
+            COMPILE_OPTIONS "${RNNOISE_X86_64_V3_FLAG}"
+    )
+
+    target_compile_definitions(rnnoise
+        PRIVATE
+            RNNOISE_X86_64_V3=1
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# x86-64 v4
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_HAVE_X86_64_V4)
+    target_sources(rnnoise
+        PRIVATE
+            src/x86/nnet_avx512.c
+    )
+
+    set_source_files_properties(
+        src/x86/nnet_avx512.c
+        PROPERTIES
+            COMPILE_OPTIONS "${RNNOISE_X86_64_V4_FLAG}"
+    )
+
+    target_compile_definitions(rnnoise
+        PRIVATE
+            RNNOISE_X86_64_V4=1
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# Libm
+# ------------------------------------------------------------------------------
+
+set(lrintf_lib)
+
+if(NOT WIN32)
+    check_library_exists(
+        m
+        lrintf
+        ""
+        RNNOISE_HAVE_LIBM
+    )
+
+    if(RNNOISE_HAVE_LIBM)
+        target_link_libraries(rnnoise
+            PRIVATE
+                m
+        )
+
+        set(lrintf_lib "-lm")
+    endif()
+endif()
+
+# ------------------------------------------------------------------------------
+# Example
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_BUILD_EXAMPLES)
+    add_executable(rnnoise_demo
+        examples/rnnoise_demo.c
+    )
+
+    target_link_libraries(rnnoise_demo
+        PRIVATE
+            rnnoise
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# Tools
+# ------------------------------------------------------------------------------
+
+add_executable(dump_features
+    src/dump_features.c
+    src/denoise.c
+    src/pitch.c
+    src/celt_lpc.c
+    src/kiss_fft.c
+    src/parse_lpcnet_weights.c
+    src/rnnoise_tables.c
+)
+
+target_compile_definitions(dump_features
+    PRIVATE
+        TRAINING
+)
+
+target_include_directories(dump_features
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+add_executable(dump_weights_blob
+    src/write_weights.c
+)
+
+target_compile_definitions(dump_weights_blob
+    PRIVATE
+        DUMP_BINARY_WEIGHTS
+)
+
+target_include_directories(dump_weights_blob
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+if(NOT WIN32 AND RNNOISE_HAVE_LIBM)
+    target_link_libraries(dump_features
+        PRIVATE
+            m
+    )
+
+    target_link_libraries(dump_weights_blob
+        PRIVATE
+            m
+    )
+endif()
+
+# ------------------------------------------------------------------------------
+# Documentation
+# ------------------------------------------------------------------------------
+
+if(RNNOISE_BUILD_DOCS)
+    find_package(Doxygen QUIET)
+
+    if(Doxygen_FOUND)
+        doxygen_add_docs(
+            rnnoise_docs
+            ${CMAKE_CURRENT_SOURCE_DIR}/include
+            COMMENT "Generating RNNoise API documentation"
+        )
+    endif()
+endif()
+
+# ------------------------------------------------------------------------------
+# pkg-config
+# ------------------------------------------------------------------------------
+
+set(PACKAGE_VERSION "${PROJECT_VERSION}")
+
+set(prefix "${CMAKE_INSTALL_PREFIX}")
+set(exec_prefix "\${prefix}")
+set(libdir "\${prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/rnnoise.pc.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/rnnoise.pc"
+    @ONLY
+)
+
+# ------------------------------------------------------------------------------
+# CMake package
+# ------------------------------------------------------------------------------
+
+set(RNNOISE_CMAKE_INSTALL_DIR
+    "${CMAKE_INSTALL_LIBDIR}/cmake/rnnoise"
+)
+
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/rnnoise-config-version.cmake"
+    VERSION "${PROJECT_VERSION}"
+    COMPATIBILITY SameMajorVersion
+)
+
+file(WRITE
+    "${CMAKE_CURRENT_BINARY_DIR}/rnnoise-config.cmake"
+    "include(\"\${CMAKE_CURRENT_LIST_DIR}/rnnoise-targets.cmake\")\n"
+)
+
+# ------------------------------------------------------------------------------
+# Installation
+# ------------------------------------------------------------------------------
+
+install(
+    TARGETS rnnoise
+    EXPORT rnnoise-targets
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+install(
+    FILES
+        COPYING
+        AUTHORS
+        README
+    DESTINATION ${CMAKE_INSTALL_DOCDIR}
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/rnnoise.pc"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig
+)
+
+install(
+    EXPORT rnnoise-targets
+    FILE rnnoise-targets.cmake
+    NAMESPACE rnnoise::
+    DESTINATION ${RNNOISE_CMAKE_INSTALL_DIR}
+)
+
+install(
+    FILES
+        "${CMAKE_CURRENT_BINARY_DIR}/rnnoise-config.cmake"
+        "${CMAKE_CURRENT_BINARY_DIR}/rnnoise-config-version.cmake"
+    DESTINATION ${RNNOISE_CMAKE_INSTALL_DIR}
+)
+
+if(Doxygen_FOUND)
+    install(
+        DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/html/"
+        DESTINATION ${CMAKE_INSTALL_DOCDIR}/html
+    )
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,12 +355,6 @@ endif()
 
 add_executable(dump_features
     src/dump_features.c
-    src/denoise.c
-    src/pitch.c
-    src/celt_lpc.c
-    src/kiss_fft.c
-    src/parse_lpcnet_weights.c
-    src/rnnoise_tables.c
 )
 
 target_compile_definitions(dump_features
@@ -373,6 +367,11 @@ target_include_directories(dump_features
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src
+)
+
+target_link_libraries(dump_features
+    PRIVATE
+        rnnoise
 )
 
 add_executable(dump_weights_blob

--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,7 @@ if RNN_ENABLE_X86_RTCD
 RNNOISE_SOURCES += $(X86_RTCD) \
                    $(RNNOISE_SOURCES_SSE4_2) \
                    $(RNNOISE_SOURCES_AVX2)
+endif
 
 librnnoise_la_SOURCES = $(RNNOISE_SOURCES)
 librnnoise_la_LIBADD = $(DEPS_LIBS) $(lrintf_lib) $(LIBM)

--- a/Makefile.am
+++ b/Makefile.am
@@ -39,15 +39,16 @@ RNNOISE_SOURCES = \
 	src/rnnoise_data.c \
 	src/rnnoise_tables.c
 
-RNNOISE_SOURCES_SSE4_1 = src/x86/nnet_sse4_1.c
+X86_RTCD = src/x86/x86_dnn_map.c \
+           src/x86/x86cpu.c
+
+RNNOISE_SOURCES_SSE4_2 = src/x86/nnet_sse4_2.c
 RNNOISE_SOURCES_AVX2 = src/x86/nnet_avx2.c
 
-X86_RTCD = src/x86/x86_dnn_map.c \
-	   src/x86/x86cpu.c
-
 if RNN_ENABLE_X86_RTCD
-RNNOISE_SOURCES += $(X86_RTCD) $(RNNOISE_SOURCES_SSE4_1) $(RNNOISE_SOURCES_AVX2)
-endif
+RNNOISE_SOURCES += $(X86_RTCD) \
+                   $(RNNOISE_SOURCES_SSE4_2) \
+                   $(RNNOISE_SOURCES_AVX2)
 
 librnnoise_la_SOURCES = $(RNNOISE_SOURCES)
 librnnoise_la_LIBADD = $(DEPS_LIBS) $(lrintf_lib) $(LIBM)
@@ -162,8 +163,8 @@ dist-hook:
 .PHONY: rnnoise install-rnnoise docs install-docs
 
 if RNN_ENABLE_X86_RTCD
-SSE4_1_OBJ = $(RNNOISE_SOURCES_SSE4_1:.c=.lo)
-$(SSE4_1_OBJ): CFLAGS += $(OPUS_X86_SSE4_1_CFLAGS)
+SSE4_2_OBJ = $(RNNOISE_SOURCES_SSE4_2:.c=.lo)
+$(SSE4_2_OBJ): CFLAGS += $(OPUS_X86_SSE4_2_CFLAGS)
 
 AVX2_OBJ = $(RNNOISE_SOURCES_AVX2:.c=.lo)
 $(AVX2_OBJ): CFLAGS += $(OPUS_X86_AVX2_CFLAGS)

--- a/README
+++ b/README
@@ -18,7 +18,7 @@ Optionally:
 
 It is recommended to either set -march= in the CFLAGS to an architecture
 with AVX2 support or to add --enable-x86-rtcd to the configure script
-so that AVX2 (or SSE4.1) can at least be used as an option.
+so that AVX2 (or SSE4.2) can at least be used as an option.
 Note that the autogen.sh script will automatically download the model files
 from the Xiph.Org servers, since those are too large to put in Git.
 

--- a/configure.ac
+++ b/configure.ac
@@ -86,18 +86,23 @@ AS_IF([test "$enable_dnn_debug_float" = "no"], [
        AC_DEFINE([DISABLE_DEBUG_FLOAT], [1], [Disable DNN debug float])
 ])
 
-OPUS_X86_SSE4_1_CFLAGS='-msse4.1'
-OPUS_X86_AVX2_CFLAGS='-mavx -mfma -mavx2'
-AC_SUBST([OPUS_X86_SSE4_1_CFLAGS])
+OPUS_X86_SSE42_CFLAGS='-march=x86-64-v2'
+OPUS_X86_AVX2_CFLAGS='-march=x86-64-v3'
+AC_SUBST([OPUS_X86_SSE4_2_CFLAGS])
 AC_SUBST([OPUS_X86_AVX2_CFLAGS])
+
 AC_ARG_ENABLE([x86-rtcd],
   AS_HELP_STRING([--enable-x86-rtcd], [x86 rtcd]),,
   enable_x86_rtcd=no)
-AM_CONDITIONAL([RNN_ENABLE_X86_RTCD], [test "$enable_x86_rtcd" = "yes"])
+
+AM_CONDITIONAL([RNN_ENABLE_X86_RTCD],
+  [test "$enable_x86_rtcd" = "yes"])
 
 AS_IF([test "$enable_x86_rtcd" = "yes"], [
-  AC_DEFINE([RNN_ENABLE_X86_RTCD], [1], [Enable x86 rtcd])
-  AC_DEFINE([CPU_INFO_BY_ASM], [1], [RTCD from ASM only for now])
+  AC_DEFINE([RNNOISE_ENABLE_X86_RTCD], [1], [Enable x86 RTCD])
+  AC_DEFINE([RNNOISE_CPU_INFO_BY_ASM], [1], [Use assembly CPU detection])
+  AC_DEFINE([RNNOISE_X86_64_V2], [1], [Enable x86-64 v2])
+  AC_DEFINE([RNNOISE_X86_64_V3], [1], [Enable x86-64 v3])
 ])
 
 AS_CASE(["$ac_cv_search_lrintf"],

--- a/include/rnnoise.h
+++ b/include/rnnoise.h
@@ -34,18 +34,20 @@
 extern "C" {
 #endif
 
-#ifndef RNNOISE_EXPORT
-# if defined(WIN32)
-#  if defined(RNNOISE_BUILD) && defined(DLL_EXPORT)
+#if !defined(RNNOISE_EXPORT) && !defined(RNNOISE_STATIC)
+# if defined(_WIN32)
+#  if defined(rnnoise_EXPORTS) || defined(RNNOISE_BUILD)
 #   define RNNOISE_EXPORT __declspec(dllexport)
 #  else
-#   define RNNOISE_EXPORT
+#   define RNNOISE_EXPORT __declspec(dllimport)
 #  endif
-# elif defined(__GNUC__) && defined(RNNOISE_BUILD)
-#  define RNNOISE_EXPORT __attribute__ ((visibility ("default")))
-# else
-#  define RNNOISE_EXPORT
+# elif defined(__GNUC__)
+#  define RNNOISE_EXPORT __attribute__((visibility("default")))
 # endif
+#endif
+
+#ifndef RNNOISE_EXPORT
+# define RNNOISE_EXPORT
 #endif
 
 typedef struct DenoiseState DenoiseState;

--- a/src/celt_lpc.h
+++ b/src/celt_lpc.h
@@ -31,7 +31,7 @@
 #include "arch.h"
 #include "common.h"
 
-#if defined(OPUS_X86_MAY_HAVE_SSE4_1)
+#if defined(OPUS_X86_MAY_HAVE_SSE4_2)
 #include "x86/celt_lpc_sse.h"
 #endif
 

--- a/src/dump_features.c
+++ b/src/dump_features.c
@@ -30,7 +30,10 @@
 #endif
 
 #define _USE_MATH_DEFINES
-#ifndef _WIN32
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
 #include <unistd.h>
 #endif
 
@@ -316,7 +319,11 @@ int main(int argc, char **argv) {
   char *argv0;
   char *rir_filename = NULL;
   struct rir_list rirs;
+#ifdef _WIN32
+  seed = GetCurrentProcessId();
+#else
   seed = getpid();
+#endif
   srand(seed);
   st = rnnoise_create(NULL);
   noisy = rnnoise_create(NULL);

--- a/src/dump_features.c
+++ b/src/dump_features.c
@@ -29,11 +29,14 @@
 #include "config.h"
 #endif
 
+#define _USE_MATH_DEFINES
+#ifndef _WIN32
+#include <unistd.h>
+#endif
 
 #include <stdio.h>
 #include <math.h>
 #include <stdlib.h>
-#include <unistd.h>
 #include <errno.h>
 #include "rnnoise.h"
 #include "common.h"

--- a/src/nnet.h
+++ b/src/nnet.h
@@ -98,9 +98,9 @@ typedef struct {
 #define compute_linear_c rnn_compute_linear_c
 #define compute_activation_c rnn_compute_activation_c
 #define compute_conv2d_c rnn_compute_conv2d_c
-#define compute_linear_sse4_1 rnn_compute_linear_sse4_1
-#define compute_activation_sse4_1 rnn_compute_activation_sse4_1
-#define compute_conv2d_sse4_1 rnn_compute_conv2d_sse4_1
+#define compute_linear_sse4_2 rnn_compute_linear_sse4_2
+#define compute_activation_sse4_2 rnn_compute_activation_sse4_2
+#define compute_conv2d_sse4_2 rnn_compute_conv2d_sse4_2
 #define compute_linear_avx2 rnn_compute_linear_avx2
 #define compute_activation_avx2 rnn_compute_activation_avx2
 #define compute_conv2d_avx2 rnn_compute_conv2d_avx2

--- a/src/vec_avx.h
+++ b/src/vec_avx.h
@@ -40,7 +40,7 @@
 
 #define USE_SU_BIAS
 
-#ifndef __SSE_4_1__
+#ifndef __SSE_4_2__
 static inline __m128 mm_floor_ps(__m128 x) {
   __m128 half = _mm_set1_ps(0.5);
   return _mm_cvtepi32_ps(_mm_cvtps_epi32(_mm_sub_ps(x, half)));
@@ -50,7 +50,7 @@ static inline __m128 mm_floor_ps(__m128 x) {
 #endif
 
 
-/* If we don't have AVX available, emulate what we need with SSE up to 4.1. */
+/* If we don't have AVX available, emulate what we need with SSE up to 4.2. */
 #ifndef __AVX__
 
 typedef struct {
@@ -161,7 +161,7 @@ static inline mm256_emu mm256_insertf128_ps(mm256_emu dst, __m128 src, int i) {
 
 
 
-/* If we don't have AVX2 available, emulate what we need with SSE up to 4.1. */
+/* If we don't have AVX2 available, emulate what we need with SSE up to 4.2. */
 #ifndef __AVX2__
 
 typedef struct {

--- a/src/x86/dnn_x86.h
+++ b/src/x86/dnn_x86.h
@@ -31,15 +31,23 @@
 #include "cpu_support.h"
 #include "opus_types.h"
 
-void compute_linear_sse4_1(const LinearLayer *linear, float *out, const float *in);
-void compute_activation_sse4_1(float *output, const float *input, int N, int activation);
-void compute_conv2d_sse4_1(const Conv2dLayer *conv, float *out, float *mem, const float *in, int height, int hstride, int activation);
+#ifdef RNNOISE_X86_64_V2
+void compute_linear_sse4_2(const LinearLayer *linear, float *out, const float *in);
+void compute_activation_sse4_2(float *output, const float *input, int N, int activation);
+void compute_conv2d_sse4_2(const Conv2dLayer *conv, float *out, float *mem, const float *in, int height, int hstride, int activation);
+#endif
 
+#ifdef RNNOISE_X86_64_V3
 void compute_linear_avx2(const LinearLayer *linear, float *out, const float *in);
 void compute_activation_avx2(float *output, const float *input, int N, int activation);
 void compute_conv2d_avx2(const Conv2dLayer *conv, float *out, float *mem, const float *in, int height, int hstride, int activation);
+#endif
 
-
+#ifdef RNNOISE_X86_64_V4
+void compute_linear_avx512(const LinearLayer* linear, float* out, const float* in);
+void compute_activation_avx512(float* output, const float* input, int N, int activation);
+void compute_conv2d_avx512(const Conv2dLayer* conv, float* out, float* mem, const float* in, int height, int hstride, int activation);
+#endif
 
 #ifdef RNN_ENABLE_X86_RTCD
 

--- a/src/x86/nnet_avx2.c
+++ b/src/x86/nnet_avx2.c
@@ -25,6 +25,8 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef RNNOISE_X86_64_V3
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -38,3 +40,4 @@
 #define RTCD_ARCH avx2
 
 #include "nnet_arch.h"
+#endif

--- a/src/x86/nnet_avx512.c
+++ b/src/x86/nnet_avx512.c
@@ -1,5 +1,5 @@
-/* Copyright (c) 2010 Xiph.Org Foundation
- * Copyright (c) 2013 Parrot */
+/* Copyright (c) 2018-2019 Mozilla
+                 2023 Amazon */
 /*
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions
@@ -15,8 +15,8 @@
    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-   A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER
-   OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+   A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR
+   CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
    EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
    PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
    PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
@@ -25,30 +25,19 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-#ifndef CPU_SUPPORT_H
-#define CPU_SUPPORT_H
+#ifdef RNNOISE_X86_64_V4
 
-#include "opus_types.h"
-#include "common.h"
-
-#ifdef RNN_ENABLE_X86_RTCD
-
-#include "x86/x86cpu.h"
-/* We currently support 4 x86 variants:
- * arch[0] -> sse2
- * arch[1] -> sse4.2
- * arch[2] -> avx2
- * arch[3] -> avx512
- */
-#define OPUS_ARCHMASK 3
-int rnn_select_arch(void);
-
-#else
-#define OPUS_ARCHMASK 0
-
-static OPUS_INLINE int rnn_select_arch(void)
-{
-  return 0;
-}
+#ifdef HAVE_CONFIG_H
+#include "config.h"
 #endif
+
+#include "x86/x86_arch_macros.h"
+
+#ifndef __AVX512F__
+#error nnet_avx512.c is being compiled without AVX512 enabled
+#endif
+
+#define RTCD_ARCH avx512
+
+#include "nnet_arch.h"
 #endif

--- a/src/x86/nnet_sse4_2.c
+++ b/src/x86/nnet_sse4_2.c
@@ -25,16 +25,19 @@
    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
+#ifdef RNNOISE_X86_64_V2
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
 
 #include "x86/x86_arch_macros.h"
 
-#ifndef __SSE4_1__
-#error nnet_sse4_1.c is being compiled without SSE4.1 enabled
+#if !defined(__SSE4_2__) && !defined(_MSC_VER)
+#error nnet_sse4_2.c is being compiled without SSE4.2 enabled
 #endif
 
-#define RTCD_ARCH sse4_1
+#define RTCD_ARCH sse4_2
 
 #include "nnet_arch.h"
+#endif

--- a/src/x86/x86_arch_macros.h
+++ b/src/x86/x86_arch_macros.h
@@ -26,21 +26,21 @@
 
 #ifdef _MSC_VER
 
-# ifdef OPUS_X86_MAY_HAVE_SSE
+# if defined(OPUS_X86_MAY_HAVE_SSE) || defined(_M_AMD64)
 #  ifndef __SSE__
 #   define __SSE__
 #  endif
 # endif
 
-# ifdef OPUS_X86_MAY_HAVE_SSE2
+# if defined(OPUS_X86_MAY_HAVE_SSE2) || defined(_M_AMD64)
 #  ifndef __SSE2__
 #   define __SSE2__
 #  endif
 # endif
 
-# ifdef OPUS_X86_MAY_HAVE_SSE4_1
-#  ifndef __SSE4_1__
-#   define __SSE4_1__
+# ifdef OPUS_X86_MAY_HAVE_SSE4_2
+#  ifndef __SSE4_2__
+#   define __SSE4_2__
 #  endif
 # endif
 

--- a/src/x86/x86_dnn_map.c
+++ b/src/x86/x86_dnn_map.c
@@ -41,8 +41,21 @@ void (*const RNN_COMPUTE_LINEAR_IMPL[OPUS_ARCHMASK + 1])(
          const float *in
 ) = {
   compute_linear_c,                /* non-sse */
-  MAY_HAVE_SSE4_1(compute_linear), /* sse4.1  */
-  MAY_HAVE_AVX2(compute_linear)  /* avx  */
+#ifdef RNNOISE_X86_64_V2
+  MAY_HAVE_SSE4_2(compute_linear), /* sse4.2  */
+#else
+  compute_linear_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V3
+  MAY_HAVE_AVX2(compute_linear),  /* avx2  */
+#else
+  compute_linear_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V4
+  MAY_HAVE_AVX512(compute_linear)  /* avx512  */
+#else
+  compute_linear_c,                /* non-sse */
+#endif
 };
 
 void (*const RNN_COMPUTE_ACTIVATION_IMPL[OPUS_ARCHMASK + 1])(
@@ -52,8 +65,21 @@ void (*const RNN_COMPUTE_ACTIVATION_IMPL[OPUS_ARCHMASK + 1])(
          int activation
 ) = {
   compute_activation_c,                /* non-sse */
-  MAY_HAVE_SSE4_1(compute_activation), /* sse4.1  */
-  MAY_HAVE_AVX2(compute_activation)  /* avx  */
+#ifdef RNNOISE_X86_64_V2
+  MAY_HAVE_SSE4_2(compute_activation), /* sse4.2  */
+#else
+  compute_activation_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V3
+  MAY_HAVE_AVX2(compute_activation),  /* avx2  */
+#else
+  compute_activation_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V4
+  MAY_HAVE_AVX512(compute_activation)  /* avx512  */
+#else
+  compute_activation_c,                /* non-sse */
+#endif
 };
 
 void (*const RNN_COMPUTE_CONV2D_IMPL[OPUS_ARCHMASK + 1])(
@@ -66,8 +92,21 @@ void (*const RNN_COMPUTE_CONV2D_IMPL[OPUS_ARCHMASK + 1])(
          int activation
 ) = {
   compute_conv2d_c,                /* non-sse */
-  MAY_HAVE_SSE4_1(compute_conv2d), /* sse4.1  */
-  MAY_HAVE_AVX2(compute_conv2d)  /* avx  */
+#ifdef RNNOISE_X86_64_V2
+  MAY_HAVE_SSE4_2(compute_conv2d), /* sse4.2  */
+#else
+  compute_conv2d_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V3
+  MAY_HAVE_AVX2(compute_conv2d),  /* avx2  */
+#else
+  compute_conv2d_c,                /* non-sse */
+#endif
+#ifdef RNNOISE_X86_64_V4
+  MAY_HAVE_AVX512(compute_conv2d)  /* avx512  */
+#else
+  compute_conv2d_c,                /* non-sse */
+#endif
 };
 
 

--- a/src/x86/x86cpu.c
+++ b/src/x86/x86cpu.c
@@ -35,12 +35,21 @@
 
 #ifdef RNN_ENABLE_X86_RTCD
 
-#if defined(_MSC_VER)
+#ifdef _WIN32
+#include "Windows.h"
+#endif
+
+#ifdef _MSC_VER
 
 #include <intrin.h>
+#include <immintrin.h>
 static _inline void cpuid(unsigned int CPUInfo[4], unsigned int InfoType)
 {
     __cpuid((int*)CPUInfo, InfoType);
+}
+static _inline unsigned long long xgetbv0(void)
+{
+    return _xgetbv(0);
 }
 
 #else
@@ -91,67 +100,137 @@ static void cpuid(unsigned int CPUInfo[4], unsigned int InfoType)
 #endif
 }
 
+static unsigned long long xgetbv0(void)
+{
+#if defined(CPU_INFO_BY_ASM)
+    unsigned int eax;
+    unsigned int edx;
+
+    __asm__ __volatile__(
+        "xgetbv":
+        "=a" (eax),
+        "=d" (edx) :
+        "c" (0)
+        );
+
+    return ((unsigned long long)edx << 32) |
+        (unsigned long long)eax;
+
+#elif defined(CPU_INFO_BY_C)
+    return _xgetbv(0);
+
+#else
+# error "Configured to use x86 RTCD, but no XGETBV detection method available. " \
+        "Reconfigure with --disable-rtcd (or send patches)."
+#endif
+}
 #endif
 
-typedef struct CPU_Feature{
-    /*  SIMD: 128-bit */
-    int HW_SSE;
-    int HW_SSE2;
-    int HW_SSE41;
-    /*  SIMD: 256-bit */
-    int HW_AVX2;
-} CPU_Feature;
-
-static void rnn_cpu_feature_check(CPU_Feature *cpu_feature)
+static int rnn_cpu_feature_check(void)
 {
+    const unsigned int v2_ecx_mask =
+        (1U << 0) | (1U << 9) | (1U << 13) |
+        (1U << 19) | (1U << 20) | (1U << 23);
+
+    const unsigned int v3_ecx_mask =
+        (1U << 12) | (1U << 22) | (1U << 27) | (1U << 28);
+
+    const unsigned int v3_ebx_mask =
+        (1U << 3) | (1U << 5) | (1U << 8);
+
+    const unsigned int v4_ebx_mask =
+        (1U << 16) | (1U << 17) | (1U << 28) |
+        (1U << 30) | (1U << 31);
+
+    const unsigned long long avx_xcr0_mask = 0x06ULL;
+    const unsigned long long avx512_xcr0_mask = 0xE6ULL;
+
+#ifdef _WIN32
+    const DWORD64 avx_xstate_mask = XSTATE_AVX;
+    const DWORD64 avx512_xstate_mask = XSTATE_AVX |
+        XSTATE_AVX512_KMASK |
+        XSTATE_AVX512_ZMM_H |
+        XSTATE_AVX512_ZMM;
+#endif
+
     unsigned int info[4];
-    unsigned int nIds = 0;
+    unsigned int nIds;
+    unsigned long long xcr0;
+#ifdef _WIN32
+    DWORD64 xstate;
+#endif
 
     cpuid(info, 0);
     nIds = info[0];
 
-    if (nIds >= 1){
-        cpuid(info, 1);
-        cpu_feature->HW_SSE = (info[3] & (1 << 25)) != 0;
-        cpu_feature->HW_SSE2 = (info[3] & (1 << 26)) != 0;
-        cpu_feature->HW_SSE41 = (info[2] & (1 << 19)) != 0;
-        cpu_feature->HW_AVX2 = (info[2] & (1 << 28)) != 0 && (info[2] & (1 << 12)) != 0;
-        if (cpu_feature->HW_AVX2 && nIds >= 7) {
-            cpuid(info, 7);
-            cpu_feature->HW_AVX2 = cpu_feature->HW_AVX2 && (info[1] & (1 << 5)) != 0;
-        } else {
-            cpu_feature->HW_AVX2 = 0;
-        }
-    }
-    else {
-        cpu_feature->HW_SSE = 0;
-        cpu_feature->HW_SSE2 = 0;
-        cpu_feature->HW_SSE41 = 0;
-        cpu_feature->HW_AVX2 = 0;
-    }
+    /*
+     * x86-64-v2
+     */
+    if (nIds < 1)
+        return 1;
+
+    cpuid(info, 1);
+
+    if ((info[3] & (1U << 26)) == 0 ||
+        (info[2] & v2_ecx_mask) != v2_ecx_mask)
+        return 1;
+
+    /*
+     * x86-64-v3
+     */
+    if (nIds < 7)
+        return 2;
+
+    if ((info[2] & v3_ecx_mask) != v3_ecx_mask)
+        return 2;
+
+    cpuid(info, 7);
+
+    if ((info[1] & v3_ebx_mask) != v3_ebx_mask)
+        return 2;
+
+    /*
+     * XMM + YMM state is required for v3.
+     */
+    xcr0 = xgetbv0();
+
+    if ((xcr0 & avx_xcr0_mask) != avx_xcr0_mask)
+        return 2;
+
+#ifdef _WIN32
+    xstate = GetEnabledXStateFeatures();
+
+    if ((xstate & avx_xstate_mask) != avx_xstate_mask)
+        return 2;
+#endif
+
+#ifdef RNNOISE_X86_64_V4
+    /*
+     * x86-64-v4
+     */
+    if ((info[1] & v4_ebx_mask) != v4_ebx_mask)
+        return 3;
+
+    /*
+     * Opmask + ZMM state is additionally required for v4.
+     */
+    if ((xcr0 & avx512_xcr0_mask) != avx512_xcr0_mask)
+        return 3;
+
+#ifdef _WIN32
+    if ((xstate & avx512_xstate_mask) != avx512_xstate_mask)
+        return 3;
+#endif
+
+    return 4;
+#else
+    return 3;
+#endif
 }
 
 static int rnn_select_arch_impl(void)
 {
-    CPU_Feature cpu_feature;
-    int arch;
-
-    rnn_cpu_feature_check(&cpu_feature);
-
-    arch = 0;
-    if (!cpu_feature.HW_SSE41)
-    {
-        return arch;
-    }
-    arch++;
-
-    if (!cpu_feature.HW_AVX2)
-    {
-        return arch;
-    }
-    arch++;
-
-    return arch;
+    return rnn_cpu_feature_check() - 1;
 }
 
 int rnn_select_arch(void) {

--- a/src/x86/x86cpu.h
+++ b/src/x86/x86cpu.h
@@ -28,9 +28,11 @@
 #if !defined(X86CPU_H)
 # define X86CPU_H
 
-#  define MAY_HAVE_SSE4_1(name) name ## _sse4_1
+#  define MAY_HAVE_SSE4_2(name) name ## _sse4_2
 
 #  define MAY_HAVE_AVX2(name) name ## _avx2
+
+#  define MAY_HAVE_AVX512(name) name ## _avx512
 
 # ifdef RNN_ENABLE_X86_RTCD
 int opus_select_arch(void);


### PR DESCRIPTION
Verified to compile for x64 and ARM64 from VS 2026.

Changed sse 4.1 to x86 64 v2 as MSVC doesn't have a separate level from that.

Added missing xstate checks for AVX.

Changes were AI assisted.